### PR TITLE
Switch RSI example to Alpaca

### DIFF
--- a/examples/rsi.py
+++ b/examples/rsi.py
@@ -25,14 +25,14 @@ def init(symbol, state: blankly.StrategyState):
 
 
 if __name__ == "__main__":
-    # Authenticate coinbase pro strategy
-    exchange = blankly.CoinbasePro()
+    # Authenticate Alpaca strategy
+    exchange = blankly.Alpaca()
 
-    # Use our strategy helper on coinbase pro
+    # Use our strategy helper on Alpaca
     strategy = blankly.Strategy(exchange)
 
     # Run the price event function every time we check for a new price - by default that is 15 seconds
-    strategy.add_price_event(price_event, symbol='BTC-USD', resolution='1d', init=init)
+    strategy.add_price_event(price_event, symbol='BTCUSD', resolution='1d', init=init)
 
     # Start the strategy. This will begin each of the price event ticks
     # strategy.start()


### PR DESCRIPTION
## Summary
- switch RSI example to use Alpaca exchange

## Testing
- `python -m py_compile examples/rsi.py`
- `pytest tests/exchanges/interfaces/alpaca/test_alpaca_interface.py -q` *(fails: Make sure a Keys.json file is placed in the same folder as the project working directory!)*

------
https://chatgpt.com/codex/tasks/task_e_689e2eb4e3448324b7241d84d61c836a