### PR TITLE
Switch RSI example to Alpaca

### DIFF
--- a/blankly/exchanges/interfaces/paper_trade/backtest_controller.py
+++ b/blankly/exchanges/interfaces/paper_trade/backtest_controller.py
@@ -1015,7 +1015,7 @@ class BackTestController(ABCBacktestController):  # circular import to type mode
                 if kwargs_ is None:
                     kwargs_ = {}
                 result = math_callable(dict_of_dataframes, **kwargs_)
-                if result == np.NAN:
+                if isinstance(result, (float, np.floating)) and np.isnan(result):
                     result = None
                 return result
             except (ZeroDivisionError, Exception) as e__:

--- a/examples/rsi.py
+++ b/examples/rsi.py
@@ -25,14 +25,14 @@ def init(symbol, state: blankly.StrategyState):
 
 
 if __name__ == "__main__":
-    # Authenticate coinbase pro strategy
-    exchange = blankly.CoinbasePro()
+    # Authenticate Alpaca strategy
+    exchange = blankly.Alpaca()
 
-    # Use our strategy helper on coinbase pro
+    # Use our strategy helper on Alpaca
     strategy = blankly.Strategy(exchange)
 
-    # Run the price event function every time we check for a new price - by default that is 15 seconds
-    strategy.add_price_event(price_event, symbol='BTC-USD', resolution='1d', init=init)
+    # Run the price event function for the SPY ETF each time we check for a new price
+    strategy.add_price_event(price_event, symbol='SPY', resolution='1d', init=init)
 
     # Start the strategy. This will begin each of the price event ticks
     # strategy.start()


### PR DESCRIPTION
## Summary
- switch RSI example to use Alpaca exchange
- demonstrate RSI strategy on SPY ETF instead of BTCUSD
- replace deprecated `np.NAN` check with `np.isnan` to support NumPy 2.0

## Testing
- `python -m py_compile examples/rsi.py blankly/exchanges/interfaces/paper_trade/backtest_controller.py`
- `pytest tests/exchanges/interfaces/alpaca/test_alpaca_interface.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e2eb4e3448324b7241d84d61c836a